### PR TITLE
debug(oauth): add comprehensive logging to OAuth status endpoint

### DIFF
--- a/apps/discord-bot/src/services/orchestratorApi.ts
+++ b/apps/discord-bot/src/services/orchestratorApi.ts
@@ -41,10 +41,19 @@ export class OrchestratorApiService {
 
   async healthCheck(): Promise<boolean> {
     try {
+      const healthUrl = `${this.api.defaults.baseURL}/health`;
+      apiLogger.info({ healthUrl }, 'Attempting health check');
       const response = await this.api.get('/health');
+      apiLogger.info({ status: response.status, healthUrl }, 'Health check successful');
       return response.status === 200;
     } catch (error) {
-      apiLogger.error(error, 'Health check failed');
+      const healthUrl = `${this.api.defaults.baseURL}/health`;
+      apiLogger.error({ 
+        error: error instanceof Error ? error.message : error, 
+        healthUrl,
+        baseURL: this.api.defaults.baseURL,
+        timeout: this.api.defaults.timeout 
+      }, 'Health check failed');
       return false;
     }
   }
@@ -93,10 +102,24 @@ export class OrchestratorApiService {
 
   async checkOAuthStatus(userId: string): Promise<{ authenticated: boolean; userInfo?: any }> {
     try {
+      const statusUrl = `${this.api.defaults.baseURL}/oauth/status?userId=${userId}`;
+      apiLogger.info({ statusUrl, userId }, 'Checking OAuth status');
       const response = await this.api.get(`/oauth/status?userId=${userId}`);
+      apiLogger.info({ 
+        statusUrl, 
+        userId, 
+        status: response.status, 
+        authenticated: response.data?.authenticated 
+      }, 'OAuth status check result');
       return response.data;
     } catch (error) {
-      apiLogger.error({ error, userId }, 'Failed to check OAuth status');
+      const statusUrl = `${this.api.defaults.baseURL}/oauth/status?userId=${userId}`;
+      apiLogger.error({ 
+        error: error instanceof Error ? error.message : error, 
+        userId, 
+        statusUrl,
+        baseURL: this.api.defaults.baseURL 
+      }, 'Failed to check OAuth status');
       return { authenticated: false };
     }
   }

--- a/apps/discord-bot/src/utils/config.ts
+++ b/apps/discord-bot/src/utils/config.ts
@@ -20,6 +20,13 @@ const parsed = envSchema.safeParse({
 
 export const env = parsed.success ? parsed.data : { ORCHESTRATOR_URL: 'http://localhost:3000', NODE_ENV: 'production' } as any;
 
+// Log configuration warnings
+if (!process.env.ORCHESTRATOR_URL) {
+  console.warn('⚠️  ORCHESTRATOR_URL not set, using default:', env.ORCHESTRATOR_URL);
+} else {
+  console.log('✅ ORCHESTRATOR_URL configured:', env.ORCHESTRATOR_URL);
+}
+
 export const discordConfig = {
   intents: [
     'Guilds',

--- a/apps/orchestrator/src/lean-server.ts
+++ b/apps/orchestrator/src/lean-server.ts
@@ -3,8 +3,8 @@ console.log('🔄 Starting lean orchestrator server...');
 
 // Minimal imports - avoid heavy dependencies during startup
 import 'dotenv/config';
-import express from 'express';
 import cors from 'cors';
+import express from 'express';
 import helmet from 'helmet';
 
 const app = express();

--- a/apps/orchestrator/src/routes/leagues.ts
+++ b/apps/orchestrator/src/routes/leagues.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
 
-import { listUserLeagues } from '../services/yahoo';
 import { prisma } from '../db';
+import { listUserLeagues } from '../services/yahoo';
 
 const Query = z.object({ userId: z.string().min(1) });
 

--- a/apps/orchestrator/src/routes/oauth-session.ts
+++ b/apps/orchestrator/src/routes/oauth-session.ts
@@ -2,8 +2,8 @@ import { Request, Response } from 'express';
 import { z } from 'zod';
 
 import { env } from '../config/env';
-import { randomId, signJWT } from '../utils/jwt';
 import { stateStore } from '../services/stateStore';
+import { randomId, signJWT } from '../utils/jwt';
 
 export async function createOAuthSession(req: Request, res: Response): Promise<void> {
   const Body = z.object({ discordId: z.string().min(5) });

--- a/apps/orchestrator/src/routes/oauth.ts
+++ b/apps/orchestrator/src/routes/oauth.ts
@@ -326,15 +326,37 @@ export async function tokenStatus(req: Request, res: Response): Promise<void> {
       return;
     }
     const rawUserId = String(parsed.data.userId);
+    
+    console.log('[tokenStatus] Checking auth status for rawUserId:', rawUserId);
+    
     // Allow passing a Discord ID; map to internal userId if a DiscordUser exists
     const map = await prisma.discordUser.findUnique({ where: { discordId: rawUserId } });
     const userId = map?.userId || rawUserId;
+    
+    console.log('[tokenStatus] Discord ID mapping result:', { 
+      rawUserId, 
+      foundDiscordUser: !!map, 
+      mappedUserId: map?.userId,
+      finalUserId: userId 
+    });
+    
     const tok = await prisma.yahooToken.findUnique({ where: { userId } });
+    
+    console.log('[tokenStatus] Yahoo token lookup result:', {
+      userId,
+      foundToken: !!tok,
+      expiresAt: tok?.expiresAt?.toISOString(),
+      scope: tok?.scope
+    });
+    
     if (!tok) {
+      console.log('[tokenStatus] No token found, returning not authenticated');
       res.json({ authenticated: false, userId });
       return;
     }
     const msLeft = tok.expiresAt.getTime() - Date.now();
+    
+    console.log('[tokenStatus] Token found and valid, returning authenticated');
     res.json({
       authenticated: true,
       userInfo: {

--- a/apps/orchestrator/src/routes/oauth.ts
+++ b/apps/orchestrator/src/routes/oauth.ts
@@ -2,10 +2,10 @@ import axios from 'axios';
 import { Request, Response } from 'express';
 import { z } from 'zod';
 
-import { prisma } from '../db';
 import { env } from '../config/env';
-import { verifyJWT } from '../utils/jwt';
+import { prisma } from '../db';
 import { stateStore } from '../services/stateStore';
+import { verifyJWT } from '../utils/jwt';
 
 // Use shared Prisma client
 


### PR DESCRIPTION
## Summary
- Add detailed debug logging to `tokenStatus` endpoint to diagnose OAuth authentication issues
- Track Discord ID mapping process and Yahoo token lookup results
- Help identify why stored OAuth tokens are not being detected during status checks

## Problem
OAuth callback successfully stores tokens in database, but `/auth status` returns "not authenticated" even though tokens exist. Logs show:
- OAuth tokens stored successfully for user `217105105827135498`  
- Status check returns `authenticated: false`

## Solution
Add comprehensive logging to track:
- Raw Discord ID input (`rawUserId`)
- Discord user mapping lookup results
- Final `userId` used for token lookup  
- Yahoo token existence and details
- Authentication result

## Test Plan
- [ ] Run `/auth login` in Discord to complete OAuth flow
- [ ] Run `/auth status` and check logs for detailed debugging output
- [ ] Verify logs show exact point where lookup fails
- [ ] Fix underlying issue based on debug information

🤖 Generated with [Claude Code](https://claude.ai/code)