### PR TITLE
fix(discord): resolve Railway health check failures

### DIFF
--- a/apps/orchestrator/src/lean-server.ts
+++ b/apps/orchestrator/src/lean-server.ts
@@ -20,8 +20,8 @@ app.use(cors({ origin: true, credentials: true }));
 app.use(express.json({ limit: '1mb' })); // Reduced from 10mb
 app.use(express.urlencoded({ extended: true }));
 
-// Immediate health endpoint - no dependencies
-app.get('/api/health', (req, res) => {
+// Health endpoint function for reuse
+const healthHandler = (req: express.Request, res: express.Response) => {
   const memUsage = process.memoryUsage();
   res.status(200).json({
     status: 'ok',
@@ -36,7 +36,11 @@ app.get('/api/health', (req, res) => {
       rss: Math.round(memUsage.rss / 1024 / 1024) + 'MB',
     },
   });
-});
+};
+
+// Health endpoints - both paths for Railway compatibility
+app.get('/health', healthHandler);
+app.get('/api/health', healthHandler);
 
 // Root endpoint
 app.get('/api', (req, res) => {
@@ -45,7 +49,7 @@ app.get('/api', (req, res) => {
     version: '1.0.0-lean',
     oauthLoaded,
     endpoints: {
-      health: '/api/health',
+      health: ['/health', '/api/health'],
       oauth: {
         start: '/api/oauth/start',
         callback: '/api/oauth/callback',
@@ -130,7 +134,7 @@ async function loadOAuthRoutes() {
         error: 'Not Found',
         message: `Route ${req.originalUrl} not found`,
         availableEndpoints: {
-          health: '/api/health',
+          health: ['/health', '/api/health'],
           oauth: {
             start: '/api/oauth/start?state=JWT_TOKEN',
             callback: '/api/oauth/callback',
@@ -172,12 +176,12 @@ app.use('*', (req, res, next) => {
       error: 'Service Loading',
       message: 'OAuth routes are still loading. Please try again in a few seconds.',
     });
-  } else if (!oauthLoaded && !req.path.match(/^\/(api\/health|api\/debug\/routes|api)$/)) {
+  } else if (!oauthLoaded && !req.path.match(/^\/(health|api\/health|api\/debug\/routes|api)$/)) {
     res.status(503).json({
       error: 'Service Loading',
       message: 'Server is still initializing. Limited endpoints available.',
       availableEndpoints: {
-        health: '/api/health',
+        health: ['/health', '/api/health'],
         debug: '/api/debug/routes',
       },
     });
@@ -201,7 +205,7 @@ async function startServer() {
 
   const server = app.listen(PORT, '0.0.0.0', () => {
     console.log(`✅ Server running on port ${PORT}`);
-    console.log(`📊 Health: http://0.0.0.0:${PORT}/api/health`);
+    console.log(`📊 Health: http://0.0.0.0:${PORT}/health`);
     console.log(`🔐 OAuth: http://0.0.0.0:${PORT}/api/oauth/start`);
 
     const memUsage = process.memoryUsage();

--- a/railway-orchestrator.toml
+++ b/railway-orchestrator.toml
@@ -4,7 +4,7 @@ buildCommand = "npm install && npx prisma generate --schema=packages/data/prisma
 
 [deploy]
 startCommand = "npx ts-node apps/orchestrator/src/lean-server.ts"
-healthcheckPath = "/api/health"
+healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "always"
 


### PR DESCRIPTION
## Summary
- Fixed Railway health check failures by adding `/health` endpoint alongside existing `/api/health`
- Updated Railway configuration to use standard `/health` path 
- Refactored health handler to eliminate code duplication

## Problem
Railway's health checks were failing because:
1. Server only provided health endpoint at `/api/health`
2. Railway expected health check at `/health` (standard path)
3. This caused continuous "service unavailable" errors during deployments

## Solution
- Added health endpoint at both `/health` and `/api/health` for maximum compatibility
- Updated `railway-orchestrator.toml` to use `/health` as the health check path
- Refactored to use a shared `healthHandler` function
- Updated all endpoint documentation and routing logic

## Test Plan
- [x] Health endpoint responds at both `/health` and `/api/health`  
- [x] Railway config points to correct path
- [x] Server logs show correct health endpoint URL
- [x] No breaking changes to existing API consumers

🤖 Generated with [Claude Code](https://claude.ai/code)