### PR TITLE
fix(discord): resolve Railway health check failures

### DIFF
--- a/apps/discord-bot/src/healthServer.ts
+++ b/apps/discord-bot/src/healthServer.ts
@@ -2,14 +2,27 @@ import express from 'express';
 
 export function startHealthServer() {
   const app = express();
-  const port = Number(process.env.DISCORD_HEALTH_PORT || 8081);
+  // Railway injects PORT env var - use it if available, fallback to DISCORD_HEALTH_PORT or 8081
+  const port = Number(process.env.PORT || process.env.DISCORD_HEALTH_PORT || 8081);
 
+  // Simple health endpoints
   app.get('/', (_req, res) => res.status(200).json({ status: 'ok', service: 'discord-bot' }));
   app.get('/health', (_req, res) => res.status(200).json({ status: 'ok', service: 'discord-bot' }));
+  
+  // Add error handling middleware
+  app.use((err: any, _req: any, res: any, _next: any) => {
+    console.error('Health server error:', err);
+    res.status(500).json({ status: 'error', service: 'discord-bot', error: err.message });
+  });
 
-  const server = app.listen(port, () => {
+  const server = app.listen(port, '0.0.0.0', () => {
     // eslint-disable-next-line no-console
-    console.log(`Discord health server listening on ${port}`);
+    console.log(`Discord health server listening on 0.0.0.0:${port}`);
+  });
+
+  // Handle server errors
+  server.on('error', (err) => {
+    console.error('Health server failed to start:', err);
   });
 
   return server;

--- a/apps/discord-bot/src/scripts/deploy-commands.ts
+++ b/apps/discord-bot/src/scripts/deploy-commands.ts
@@ -6,6 +6,13 @@ import { discordLogger } from '../utils/logger';
 
 async function deployCommands() {
   try {
+    if (!env.DISCORD_TOKEN) {
+      throw new Error('DISCORD_TOKEN is required for command deployment');
+    }
+    if (!env.DISCORD_CLIENT_ID) {
+      throw new Error('DISCORD_CLIENT_ID is required for command deployment');
+    }
+
     const commands = loadCommands();
     const commandData = Array.from(commands.values()).map(cmd => cmd.data.toJSON());
     


### PR DESCRIPTION
## Summary
- Fixed Discord bot health check failures on Railway by correcting port binding and interface configuration
- Resolved TypeScript compilation errors preventing proper deployment
- Added comprehensive error handling for better debugging

## Changes Made
- **Health Server Port Configuration**: Use Railway's `PORT` environment variable as primary, with fallback to `DISCORD_HEALTH_PORT` or `8081`
- **Interface Binding**: Explicitly bind health server to `0.0.0.0` instead of localhost for external accessibility
- **Error Handling**: Added middleware and server error handling for better debugging
- **TypeScript Fixes**: Added null checks for optional Discord credentials in deploy-commands script

## Test Plan
- [x] Health server starts correctly on Railway's expected port
- [x] `/health` endpoint returns HTTP 200 with proper JSON response
- [x] TypeScript compilation passes without errors  
- [x] Bot starts successfully even without Discord credentials
- [x] Server binds to external interfaces for Railway health checks

🤖 Generated with [Claude Code](https://claude.ai/code)